### PR TITLE
no need to prepend DNS

### DIFF
--- a/Networking/Sources/Networking/PKCS12.swift
+++ b/Networking/Sources/Networking/PKCS12.swift
@@ -89,13 +89,12 @@ public func generateSelfSignedCertificate(privateKey: Ed25519.SecretKey) throws 
 }
 
 func generateSubjectAlternativeName(publicKey: Ed25519.PublicKey) -> String {
-    let base32Encoded = base32Encode(publicKey.data.data)
-    return "DNS:e\(base32Encoded)"
+    generateSubjectAlternativeName(pubkey: publicKey.data.data)
 }
 
 func generateSubjectAlternativeName(pubkey: Data) -> String {
     let base32Encoded = base32Encode(pubkey)
-    return "DNS:e\(base32Encoded)"
+    return "e\(base32Encoded)"
 }
 
 func base32Encode(_ data: Data) -> String {


### PR DESCRIPTION
this is what the old code generates:

`openssl x509 -noout -text -in <CERT-PATH>`

```
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 1 (0x1)
        Signature Algorithm: ED25519
        Issuer: CN = Self-Signed Cert
        Validity
            Not Before: Dec  3 21:17:57 2024 GMT
            Not After : Dec  3 21:17:57 2025 GMT
        Subject: CN = Self-Signed Cert
        Subject Public Key Info:
            Public Key Algorithm: ED25519
                ED25519 Public-Key:
                pub:
                    08:14:54:72:b1:7e:e6:5b:df:40:00:fd:68:f2:c4:
                    40:10:c2:45:74:8a:a6:57:25:30:08:25:8d:e4:2a:
                    13:fe
        X509v3 extensions:
            X509v3 Subject Alternative Name: 
                DNS:DNS:ebakfi4vrp3tfxx2aad6wr4weiaimerlurktfojjqbasy3zbkcp7a
    Signature Algorithm: ED25519
    Signature Value:
        b8:8a:4f:af:15:8a:c5:7f:cf:44:e4:41:ce:5d:e7:91:7b:c3:
        59:27:55:d4:a0:c7:bc:77:7c:99:52:4c:07:b8:ba:75:7e:52:
        85:39:90:88:b1:03:48:e4:4b:40:a8:9d:d5:c8:b4:b9:a4:ed:
        9f:d4:18:b6:1d:5b:3e:79:08:0b
```
