### PR TITLE
try fix release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
   test:
     name: Build and Test (${{ matrix.config }})
     runs-on: [self-hosted, linux]
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       matrix:
         config: [debug, release]
@@ -100,7 +100,13 @@ jobs:
     - name: Test
       run: |
         if [ "${{ matrix.config }}" = "release" ]; then
-          ./scripts/runTests.sh test -c release
+          # Run release tests for all packages except Boka (test discovery issues)
+          for file in **/Tests; do
+            package_dir="$(dirname "$file")"
+            if [[ "$package_dir" != "Boka" ]]; then
+              swift test -c release -Xswiftc -enable-testing --package-path "$package_dir"
+            fi
+          done
         else
           make test-all
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Build
       run: |
         if [ "${{ matrix.config }}" = "release" ]; then
-          make .lib/libmsquic.a
+          make deps
           ./scripts/run.sh build -c release
         else
           make build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,12 @@ jobs:
         args: --config .swiftlint.yml --strict
 
   test:
-    name: Build and Test
+    name: Build and Test (${{ matrix.config }})
     runs-on: [self-hosted, linux]
     timeout-minutes: 30
+    strategy:
+      matrix:
+        config: [debug, release]
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
@@ -42,8 +45,9 @@ jobs:
       uses: runs-on/cache@v4
       with:
         path: '**/.build'
-        key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+        key: ${{ runner.os }}-spm-${{ matrix.config }}-${{ hashFiles('**/Package.resolved') }}
         restore-keys: |
+          ${{ runner.os }}-spm-${{ matrix.config }}-
           ${{ runner.os }}-spm-
       env:
         RUNS_ON_S3_BUCKET_CACHE: laminar-gh-action-cache
@@ -87,6 +91,16 @@ jobs:
     - name: Check rust format
       run: cargo +nightly fmt --all -- --check
     - name: Build
-      run: make build
+      run: |
+        if [ "${{ matrix.config }}" = "release" ]; then
+          ./scripts/run.sh build -c release
+        else
+          make build
+        fi
     - name: Test
-      run: make test-all
+      run: |
+        if [ "${{ matrix.config }}" = "release" ]; then
+          ./scripts/runTests.sh test -c release
+        else
+          make test-all
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
   test:
     name: Build and Test (${{ matrix.config }})
     runs-on: [self-hosted, linux]
-    timeout-minutes: 45
+    timeout-minutes: 40
     strategy:
       matrix:
         config: [debug, release]
@@ -93,6 +93,7 @@ jobs:
     - name: Build
       run: |
         if [ "${{ matrix.config }}" = "release" ]; then
+          make .lib/libmsquic.a
           ./scripts/run.sh build -c release
         else
           make build
@@ -100,13 +101,7 @@ jobs:
     - name: Test
       run: |
         if [ "${{ matrix.config }}" = "release" ]; then
-          # Run release tests for all packages except Boka (test discovery issues)
-          for file in **/Tests; do
-            package_dir="$(dirname "$file")"
-            if [[ "$package_dir" != "Boka" ]]; then
-              swift test -c release -Xswiftc -enable-testing --package-path "$package_dir"
-            fi
-          done
+          ./scripts/runTests.sh test -c release -Xswiftc -Onone -Xswiftc -whole-module-optimization -Xswiftc -package-cmo -Xswiftc -unavailable-decl-optimization=complete
         else
           make test-all
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,14 +94,14 @@ jobs:
       run: |
         if [ "${{ matrix.config }}" = "release" ]; then
           make deps
-          ./scripts/run.sh build -c release
+          ./scripts/run.sh build -c release -Xswiftc -enable-testing -Xswiftc -Onone -Xswiftc -whole-module-optimization -Xswiftc -package-cmo -Xswiftc -unavailable-decl-optimization=complete
         else
           make build
         fi
     - name: Test
       run: |
         if [ "${{ matrix.config }}" = "release" ]; then
-          ./scripts/runTests.sh test -c release -Xswiftc -Onone -Xswiftc -whole-module-optimization -Xswiftc -package-cmo -Xswiftc -unavailable-decl-optimization=complete
+          ./scripts/runTests.sh test -c release -Xswiftc -enable-testing -Xswiftc -Onone -Xswiftc -whole-module-optimization -Xswiftc -package-cmo -Xswiftc -unavailable-decl-optimization=complete
         else
           make test-all
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         cd ../../Boka
 
         # Build Swift release binary with our static libraries
-        swift build -c release -Xswiftc -Onone -Xswiftc -whole-module-optimization -Xswiftc -package-cmo -Xswiftc -unavailable-decl-optimization=complete \
+        swift build -c release \
           -Xlinker "$STATIC_LIB_DIR/lib/librocksdb.a" \
           -Xlinker "$STATIC_LIB_DIR/lib/liblz4.a" \
           -Xlinker "$STATIC_LIB_DIR/lib/libzstd.a" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         cd ../../Boka
 
         # Build Swift release binary with our static libraries
-        swift build -c release \
+        swift build -c release -Xswiftc -Onone -Xswiftc -whole-module-optimization -Xswiftc -package-cmo -Xswiftc -unavailable-decl-optimization=complete \
           -Xlinker "$STATIC_LIB_DIR/lib/librocksdb.a" \
           -Xlinker "$STATIC_LIB_DIR/lib/liblz4.a" \
           -Xlinker "$STATIC_LIB_DIR/lib/libzstd.a" \

--- a/Blockchain/Sources/Blockchain/RuntimeProtocols/Safrole.swift
+++ b/Blockchain/Sources/Blockchain/RuntimeProtocols/Safrole.swift
@@ -257,10 +257,8 @@ extension Safrole {
             let validatorQueueWithoutOffenders = withoutOffenders(offenders: offenders, validators: validatorQueue)
 
             let newCommitment = {
-                try Bandersnatch.RingCommitment(
-                    ring: validatorQueueWithoutOffenders.map { try? Bandersnatch.PublicKey(data: $0.bandersnatch) },
-                    ctx: ctx
-                ).data
+                let ring = validatorQueueWithoutOffenders.map { try? Bandersnatch.PublicKey(data: $0.bandersnatch) }
+                return try withExtendedLifetime(ring) { try Bandersnatch.RingCommitment(ring: ring, ctx: ctx).data }
             }
             let verifier = Bandersnatch.Verifier(ctx: ctx, commitment: commitment)
 

--- a/Utils/Tests/UtilsTests/DebugCheckTests.swift
+++ b/Utils/Tests/UtilsTests/DebugCheckTests.swift
@@ -16,18 +16,25 @@ struct DebugCheckTests {
 
     @Test
     func testDebugCheck() async throws {
-        try #expect(doesThrow {
-            try debugCheck(1 + 1 == 2)
-        } == true)
-        #expect(throws: DebugCheckError.self) {
-            try debugCheck(1 + 1 == 3)
-        }
-        try await #expect(awaitThrow {
-            try await debugCheck(1 + 1 == 2)
-        } == true)
+        #if DEBUG_ASSERT
+            try #expect(doesThrow {
+                try debugCheck(1 + 1 == 2)
+            } == true)
+            #expect(throws: DebugCheckError.self) {
+                try debugCheck(1 + 1 == 3)
+            }
+            try await #expect(awaitThrow {
+                try await debugCheck(1 + 1 == 2)
+            } == true)
 
-        await #expect(throws: DebugCheckError.self) {
-            try await debugCheck(1 + 1 == 3)
-        }
+            await #expect(throws: DebugCheckError.self) {
+                try await debugCheck(1 + 1 == 3)
+            }
+        #else
+            try await debugCheck(1 + 1 == 2) // Should not throw
+            try await debugCheck(1 + 1 == 3) // Should not throw
+            try await debugCheck(1 + 1 == 2) // Should not throw
+            try await debugCheck(1 + 1 == 3) // Should not throw
+        #endif
     }
 }

--- a/Utils/Tests/UtilsTests/DebugCheckTests.swift
+++ b/Utils/Tests/UtilsTests/DebugCheckTests.swift
@@ -30,11 +30,6 @@ struct DebugCheckTests {
             await #expect(throws: DebugCheckError.self) {
                 try await debugCheck(1 + 1 == 3)
             }
-        #else
-            try await debugCheck(1 + 1 == 2) // Should not throw
-            try await debugCheck(1 + 1 == 3) // Should not throw
-            try await debugCheck(1 + 1 == 2) // Should not throw
-            try await debugCheck(1 + 1 == 3) // Should not throw
         #endif
     }
 }

--- a/scripts/release.Dockerfile
+++ b/scripts/release.Dockerfile
@@ -17,7 +17,7 @@ RUN make deps
 
 WORKDIR /boka/Boka
 
-RUN swift build -c release -Xswiftc -Onone -Xswiftc -whole-module-optimization -Xswiftc -package-cmo -Xswiftc -unavailable-decl-optimization=complete
+RUN swift build -c release
 
 RUN cp $(swift build --show-bin-path -c release)/Boka /boka/boka-bin
 

--- a/scripts/release.Dockerfile
+++ b/scripts/release.Dockerfile
@@ -2,8 +2,8 @@ FROM swift:6.1-noble AS builder
 WORKDIR /boka
 
 RUN apt-get update && \
-    apt-get dist-upgrade -y -o Dpkg::Options::="--force-confold" && \
-    apt-get install -y curl build-essential cmake librocksdb-dev libzstd-dev libbz2-dev liblz4-dev
+	apt-get dist-upgrade -y -o Dpkg::Options::="--force-confold" && \
+	apt-get install -y curl build-essential cmake librocksdb-dev libzstd-dev libbz2-dev liblz4-dev
 
 # install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -17,7 +17,7 @@ RUN make deps
 
 WORKDIR /boka/Boka
 
-RUN swift build -c release -Xswiftc -Onone -Xswiftc -whole-module-optimization -Xswiftc -package-cmo -Xswiftc -unavailable-decl-optimization=complete
+RUN swift build -c release
 
 RUN cp $(swift build --show-bin-path -c release)/Boka /boka/boka-bin
 
@@ -32,26 +32,26 @@ LABEL maintainer="hello@laminar.one"
 
 # from https://github.com/swiftlang/swift-docker/blob/fad056fa5f65f926323f0ff61129cb4e6b1eec11/6.1/ubuntu/24.04/Dockerfile
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
-    binutils \
-    git \
-    unzip \
-    gnupg2 \
-    libc6-dev \
-    libcurl4-openssl-dev \
-    libedit2 \
-    libgcc-13-dev \
-    libpython3-dev \
-    libsqlite3-0 \
-    libstdc++-13-dev \
-    libxml2-dev \
-    libncurses-dev \
-    libz3-dev \
-    pkg-config \
-    tzdata \
-    zlib1g-dev \
-    librocksdb-dev \
-    && rm -r /var/lib/apt/lists/*
+	apt-get -q install -y \
+	binutils \
+	git \
+	unzip \
+	gnupg2 \
+	libc6-dev \
+	libcurl4-openssl-dev \
+	libedit2 \
+	libgcc-13-dev \
+	libpython3-dev \
+	libsqlite3-0 \
+	libstdc++-13-dev \
+	libxml2-dev \
+	libncurses-dev \
+	libz3-dev \
+	pkg-config \
+	tzdata \
+	zlib1g-dev \
+	librocksdb-dev \
+	&& rm -r /var/lib/apt/lists/*
 
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
 
@@ -65,39 +65,39 @@ ARG SWIFT_VERSION=swift-6.1-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
-    SWIFT_PLATFORM=$SWIFT_PLATFORM \
-    SWIFT_BRANCH=$SWIFT_BRANCH \
-    SWIFT_VERSION=$SWIFT_VERSION \
-    SWIFT_WEBROOT=$SWIFT_WEBROOT
+	SWIFT_PLATFORM=$SWIFT_PLATFORM \
+	SWIFT_BRANCH=$SWIFT_BRANCH \
+	SWIFT_VERSION=$SWIFT_VERSION \
+	SWIFT_WEBROOT=$SWIFT_WEBROOT
 
 RUN set -e; \
-    ARCH_NAME="$(dpkg --print-architecture)"; \
-    url=; \
-    case "${ARCH_NAME##*-}" in \
-        'amd64') \
-            OS_ARCH_SUFFIX=''; \
-            ;; \
-        'arm64') \
-            OS_ARCH_SUFFIX='-aarch64'; \
-            ;; \
-        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
-    esac; \
-    SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
-    && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \
-    && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
-    # - Grab curl here so we cache better up above
-    && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
-    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
-    && export GNUPGHOME="$(mktemp -d)" \
-    && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
-    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
-    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
-    # - Unpack the toolchain, set libs permissions, and clean up.
-    && tar -xzf swift.tar.gz --directory / --strip-components=1 \
-    && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz \
-    && apt-get purge --auto-remove -y curl
+	ARCH_NAME="$(dpkg --print-architecture)"; \
+	url=; \
+	case "${ARCH_NAME##*-}" in \
+	'amd64') \
+	OS_ARCH_SUFFIX=''; \
+	;; \
+	'arm64') \
+	OS_ARCH_SUFFIX='-aarch64'; \
+	;; \
+	*) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+	esac; \
+	SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
+	&& SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \
+	&& SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
+	# - Grab curl here so we cache better up above
+	&& export DEBIAN_FRONTEND=noninteractive \
+	&& apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+	# - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
+	&& gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+	&& gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
+	# - Unpack the toolchain, set libs permissions, and clean up.
+	&& tar -xzf swift.tar.gz --directory / --strip-components=1 \
+	&& chmod -R o+r /usr/lib/swift \
+	&& rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz \
+	&& apt-get purge --auto-remove -y curl
 
 RUN useradd -m -u 1001 -U -s /bin/sh -d /boka boka
 
@@ -105,7 +105,7 @@ COPY --from=builder /boka/boka-bin /usr/local/bin/boka
 
 # checks
 RUN ldd /usr/local/bin/boka && \
-    /usr/local/bin/boka --help
+	/usr/local/bin/boka --help
 
 USER boka
 

--- a/scripts/release.Dockerfile
+++ b/scripts/release.Dockerfile
@@ -2,8 +2,8 @@ FROM swift:6.1-noble AS builder
 WORKDIR /boka
 
 RUN apt-get update && \
-	apt-get dist-upgrade -y -o Dpkg::Options::="--force-confold" && \
-	apt-get install -y curl build-essential cmake librocksdb-dev libzstd-dev libbz2-dev liblz4-dev
+    apt-get dist-upgrade -y -o Dpkg::Options::="--force-confold" && \
+    apt-get install -y curl build-essential cmake librocksdb-dev libzstd-dev libbz2-dev liblz4-dev
 
 # install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
@@ -32,26 +32,26 @@ LABEL maintainer="hello@laminar.one"
 
 # from https://github.com/swiftlang/swift-docker/blob/fad056fa5f65f926323f0ff61129cb4e6b1eec11/6.1/ubuntu/24.04/Dockerfile
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-	apt-get -q install -y \
-	binutils \
-	git \
-	unzip \
-	gnupg2 \
-	libc6-dev \
-	libcurl4-openssl-dev \
-	libedit2 \
-	libgcc-13-dev \
-	libpython3-dev \
-	libsqlite3-0 \
-	libstdc++-13-dev \
-	libxml2-dev \
-	libncurses-dev \
-	libz3-dev \
-	pkg-config \
-	tzdata \
-	zlib1g-dev \
-	librocksdb-dev \
-	&& rm -r /var/lib/apt/lists/*
+    apt-get -q install -y \
+    binutils \
+    git \
+    unzip \
+    gnupg2 \
+    libc6-dev \
+    libcurl4-openssl-dev \
+    libedit2 \
+    libgcc-13-dev \
+    libpython3-dev \
+    libsqlite3-0 \
+    libstdc++-13-dev \
+    libxml2-dev \
+    libncurses-dev \
+    libz3-dev \
+    pkg-config \
+    tzdata \
+    zlib1g-dev \
+    librocksdb-dev \
+    && rm -r /var/lib/apt/lists/*
 
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
 
@@ -65,39 +65,39 @@ ARG SWIFT_VERSION=swift-6.1-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
-	SWIFT_PLATFORM=$SWIFT_PLATFORM \
-	SWIFT_BRANCH=$SWIFT_BRANCH \
-	SWIFT_VERSION=$SWIFT_VERSION \
-	SWIFT_WEBROOT=$SWIFT_WEBROOT
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT
 
 RUN set -e; \
-	ARCH_NAME="$(dpkg --print-architecture)"; \
-	url=; \
-	case "${ARCH_NAME##*-}" in \
-	'amd64') \
-	OS_ARCH_SUFFIX=''; \
-	;; \
-	'arm64') \
-	OS_ARCH_SUFFIX='-aarch64'; \
-	;; \
-	*) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
-	esac; \
-	SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
-	&& SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \
-	&& SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
-	# - Grab curl here so we cache better up above
-	&& export DEBIAN_FRONTEND=noninteractive \
-	&& apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
-	# - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
-	&& gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
-	&& gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
-	# - Unpack the toolchain, set libs permissions, and clean up.
-	&& tar -xzf swift.tar.gz --directory / --strip-components=1 \
-	&& chmod -R o+r /usr/lib/swift \
-	&& rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz \
-	&& apt-get purge --auto-remove -y curl
+    ARCH_NAME="$(dpkg --print-architecture)"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+    'amd64') \
+    OS_ARCH_SUFFIX=''; \
+    ;; \
+    'arm64') \
+    OS_ARCH_SUFFIX='-aarch64'; \
+    ;; \
+    *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
+    && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \
+    && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
+    # - Grab curl here so we cache better up above
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
+    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf swift.tar.gz --directory / --strip-components=1 \
+    && chmod -R o+r /usr/lib/swift \
+    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz \
+    && apt-get purge --auto-remove -y curl
 
 RUN useradd -m -u 1001 -U -s /bin/sh -d /boka boka
 
@@ -105,7 +105,7 @@ COPY --from=builder /boka/boka-bin /usr/local/bin/boka
 
 # checks
 RUN ldd /usr/local/bin/boka && \
-	/usr/local/bin/boka --help
+    /usr/local/bin/boka --help
 
 USER boka
 

--- a/scripts/release.Dockerfile
+++ b/scripts/release.Dockerfile
@@ -17,7 +17,7 @@ RUN make deps
 
 WORKDIR /boka/Boka
 
-RUN swift build -c release
+RUN swift build -c release -Xswiftc -Onone -Xswiftc -whole-module-optimization -Xswiftc -package-cmo -Xswiftc -unavailable-decl-optimization=complete
 
 RUN cp $(swift build --show-bin-path -c release)/Boka /boka/boka-bin
 
@@ -74,13 +74,13 @@ RUN set -e; \
     ARCH_NAME="$(dpkg --print-architecture)"; \
     url=; \
     case "${ARCH_NAME##*-}" in \
-    'amd64') \
-    OS_ARCH_SUFFIX=''; \
-    ;; \
-    'arm64') \
-    OS_ARCH_SUFFIX='-aarch64'; \
-    ;; \
-    *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+        'amd64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'arm64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
     esac; \
     SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
     && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \

--- a/scripts/release.Dockerfile
+++ b/scripts/release.Dockerfile
@@ -17,7 +17,7 @@ RUN make deps
 
 WORKDIR /boka/Boka
 
-RUN swift build -c release
+RUN swift build -c release  -Xswiftc -Onone -Xswiftc -whole-module-optimization -Xswiftc -package-cmo -Xswiftc -unavailable-decl-optimization=complete
 
 RUN cp $(swift build --show-bin-path -c release)/Boka /boka/boka-bin
 


### PR DESCRIPTION
Release build with default optimization can pass traces tests by extend lifetime in an ffi call, but other similar code don't have this issue, so this could be a special case. 

And testing with release build revealed other differences, for instance sth related to weak var in blockchain services, which seems to have no way to fix. I guess we have to turn off some optimization.

I went through swift optimization levels (-O, -Osize, -Onone), with related flags only (trying all flags will take too long since i did not find the specific sets of optimization flags for each level), and run our test that can fail in default release build
- `-O` (performance over code size) does not work no matter which flag is used
- `-Osize` (prioritizes code size over perf) does not work no matter which flag is used
- `-Onone`(no optimizations) works of course, but can enable some optimization flags after it

tested flags:
- `-disable-actor-data-race-checks`
- `-enforce-exclusivity=none`
- `-remove-runtime-asserts`
- `-disable-dynamic-actor-isolation`
- `-strict-concurrency=minimal`
- `-whole-module-optimization`
- `-no-whole-module-optimization`
- `-unavailable-decl-optimization=none`
- `-disable-autolinking-runtime-compatibility-concurrency`
- `-disable-autolinking-runtime-compatibility-dynamic-replacements`
- `-disable-migrator-fixits`

---

Aded ci release tests to prevent unexpected release build bugs in future
